### PR TITLE
Fix PHP warning in WooCommerce 2.6 onwards 🐞

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Will be required for WooCommerce shops using the integration from WooCommerce 2.
 
 # Changelog
 
+* 2.1.4 - Fixed bug causing PHP warning with WooCommerce 2.6 onwards
 * 2.1.3 - Compatibility with new woocommerce
 * 2.1.2 - Fixed bug with not tracking orders.
 * 2.1.1 - Fixed bug with empty list of categories, list of contributors was updated

--- a/includes/class-wc-piwik.php
+++ b/includes/class-wc-piwik.php
@@ -510,7 +510,7 @@ class WC_Piwik extends WC_Integration
         $this->settings[$key] = $value;
     }
 
-    public function validate_checkbox_field($key)
+    public function validate_checkbox_field($key, $value)
     {
         if ($this->validateIntegrationValues()) {
             return 'yes';
@@ -523,6 +523,7 @@ class WC_Piwik extends WC_Integration
 
         return $status;
     }
+    
     protected function validateIntegrationValues()
     {
         // ignore field validation if piwik pro integration values are provided

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: Piwik Pro
 Tags: woocommerce, piwik
 Donate link: http://piwik.pro/
 Requires at least: 3.5
-Tested up to: 4.6.1
-Stable tag: 2.1.3
+Tested up to: 4.7.3
+Stable tag: 2.1.4
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -29,8 +29,12 @@ Or use the automatic installation wizard through your admin panel, just search f
 In admin menu, click on WooCommerce -> Settings, and switch to Integration tab
 
 == Changelog ==
+= 2.1.4 - 21/03/2017 =
+ * Fixed Warning with WooCommerce 2.6 onwards
+
 = 2.1.3 - 19/09/2016 =
  * Compatibility with new woocommerce
+
 = 2.1.2 - 15/01/2016 =
  * Fixed issue with not traked orders
 

--- a/woocommerce-piwik-integration.php
+++ b/woocommerce-piwik-integration.php
@@ -6,7 +6,7 @@ Plugin URI: http://wordpress.org/plugins/woocommerce-piwik-integration/
 Description: Allows Piwik and Piwik PRO tracking code to be inserted into WooCommerce store pages.
 Author: Piwik PRO
 Author URI: http://www.piwik.pro
-Version: 2.1.3
+Version: 2.1.4
 */
 
 function wc_piwik_add_integration( $integrations ) {


### PR DESCRIPTION
A [change](https://github.com/woocommerce/woocommerce/commit/5525fadc09c100450da8b504044598c48e7e345e) introduced in WooCommerce 2.6 onwards affected the `validate_checkbox_field` function in the `WC_Settings_API` that is used by `WC_Piwik`.

Users of the WooCommerce Piwik plugin with versions of WooCommerce later than 2.6 may see a warning similar to the following:

```
E_WARNING: Declaration of WC_Piwik::validate_checkbox_field($key) should be compatible with WC_Settings_API::validate_checkbox_field($key, $value)
```

This error has been reported in a number of WordPress.org [support topics](https://wordpress.org/support/plugin/woocommerce-piwik-integration/) for the plugin.

This PR aims to fix the above warning by adding the missing `$value` argument to the `validate_checkbox_field` function.

---

I have bumped the plugin version to 2.1.4 and updated both readme files to include this in the change log in the hope of a fast release to the WordPress.org plugins directory.

Please let me know if you have any questions.